### PR TITLE
Add support for multiple "-check.f" (OR-match)

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -1,9 +1,9 @@
 // Copyright (c) 2012 The Go Authors. All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 //    * Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
 //    * Redistributions in binary form must reproduce the above
@@ -13,7 +13,7 @@
 //    * Neither the name of Google Inc. nor the names of its
 // contributors may be used to endorse or promote products derived from
 // this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -42,7 +42,7 @@ func (s *BenchmarkS) TestBenchmark(c *C) {
 		Output:        &output,
 		Benchmark:     true,
 		BenchmarkTime: 10000000,
-		Filter:        "Benchmark1",
+		Filters:       []string{"Benchmark1"},
 	}
 	Run(&helper, &runConf)
 	c.Check(helper.calls[0], Equals, "SetUpSuite")
@@ -65,7 +65,7 @@ func (s *BenchmarkS) TestBenchmarkBytes(c *C) {
 		Output:        &output,
 		Benchmark:     true,
 		BenchmarkTime: 10000000,
-		Filter:        "Benchmark2",
+		Filters:       []string{"Benchmark2"},
 	}
 	Run(&helper, &runConf)
 
@@ -81,7 +81,7 @@ func (s *BenchmarkS) TestBenchmarkMem(c *C) {
 		Benchmark:     true,
 		BenchmarkMem:  true,
 		BenchmarkTime: 10000000,
-		Filter:        "Benchmark3",
+		Filters:       []string{"Benchmark3"},
 	}
 	Run(&helper, &runConf)
 

--- a/run_test.go
+++ b/run_test.go
@@ -196,7 +196,107 @@ func (s *RunS) TestPrintRunError(c *C) {
 // -----------------------------------------------------------------------
 // Verify that the method pattern flag works correctly.
 
-func (s *RunS) TestFilterTestName(c *C) {
+func (s *RunS) TestFiltersTestName(c *C) {
+	helper := FixtureHelper{}
+	output := String{}
+	runConf := RunConf{Output: &output, Filters: []string{"Test[91]"}}
+	Run(&helper, &runConf)
+	c.Check(helper.calls[0], Equals, "SetUpSuite")
+	c.Check(helper.calls[1], Equals, "SetUpTest")
+	c.Check(helper.calls[2], Equals, "Test1")
+	c.Check(helper.calls[3], Equals, "TearDownTest")
+	c.Check(helper.calls[4], Equals, "TearDownSuite")
+	c.Check(len(helper.calls), Equals, 5)
+}
+
+func (s *RunS) TestFiltersTestNameWithAll(c *C) {
+	helper := FixtureHelper{}
+	output := String{}
+	runConf := RunConf{Output: &output, Filters: []string{".*"}}
+	Run(&helper, &runConf)
+	c.Check(helper.calls[0], Equals, "SetUpSuite")
+	c.Check(helper.calls[1], Equals, "SetUpTest")
+	c.Check(helper.calls[2], Equals, "Test1")
+	c.Check(helper.calls[3], Equals, "TearDownTest")
+	c.Check(helper.calls[4], Equals, "SetUpTest")
+	c.Check(helper.calls[5], Equals, "Test2")
+	c.Check(helper.calls[6], Equals, "TearDownTest")
+	c.Check(helper.calls[7], Equals, "TearDownSuite")
+	c.Check(len(helper.calls), Equals, 8)
+}
+
+func (s *RunS) TestFiltersSuiteName(c *C) {
+	helper := FixtureHelper{}
+	output := String{}
+	runConf := RunConf{Output: &output, Filters: []string{"FixtureHelper"}}
+	Run(&helper, &runConf)
+	c.Check(helper.calls[0], Equals, "SetUpSuite")
+	c.Check(helper.calls[1], Equals, "SetUpTest")
+	c.Check(helper.calls[2], Equals, "Test1")
+	c.Check(helper.calls[3], Equals, "TearDownTest")
+	c.Check(helper.calls[4], Equals, "SetUpTest")
+	c.Check(helper.calls[5], Equals, "Test2")
+	c.Check(helper.calls[6], Equals, "TearDownTest")
+	c.Check(helper.calls[7], Equals, "TearDownSuite")
+	c.Check(len(helper.calls), Equals, 8)
+}
+
+func (s *RunS) TestFiltersSuiteNameAndTestName(c *C) {
+	helper := FixtureHelper{}
+	output := String{}
+	runConf := RunConf{Output: &output, Filters: []string{"FixtureHelper\\.Test2"}}
+	Run(&helper, &runConf)
+	c.Check(helper.calls[0], Equals, "SetUpSuite")
+	c.Check(helper.calls[1], Equals, "SetUpTest")
+	c.Check(helper.calls[2], Equals, "Test2")
+	c.Check(helper.calls[3], Equals, "TearDownTest")
+	c.Check(helper.calls[4], Equals, "TearDownSuite")
+	c.Check(len(helper.calls), Equals, 5)
+}
+
+func (s *RunS) TestFiltersAllOut(c *C) {
+	helper := FixtureHelper{}
+	output := String{}
+	runConf := RunConf{Output: &output, Filters: []string{"NotFound"}}
+	Run(&helper, &runConf)
+	c.Check(len(helper.calls), Equals, 0)
+}
+
+func (s *RunS) TestRequirePartialMatch(c *C) {
+	helper := FixtureHelper{}
+	output := String{}
+	runConf := RunConf{Output: &output, Filters: []string{"est"}}
+	Run(&helper, &runConf)
+	c.Check(len(helper.calls), Equals, 8)
+}
+
+func (s *RunS) TestFiltersError(c *C) {
+	helper := FixtureHelper{}
+	output := String{}
+	runConf := RunConf{Output: &output, Filters: []string{"]["}}
+	result := Run(&helper, &runConf)
+	c.Check(result.String(), Equals,
+		"ERROR: Bad filter expression: error parsing regexp: missing closing ]: `[`")
+	c.Check(len(helper.calls), Equals, 0)
+}
+
+func (s *RunS) TestFiltersMultiple(c *C) {
+	helper := FixtureHelper{}
+	output := String{}
+	runConf := RunConf{Output: &output, Filters: []string{"Test1", "Test2"}}
+	Run(&helper, &runConf)
+	c.Check(helper.calls[0], Equals, "SetUpSuite")
+	c.Check(helper.calls[1], Equals, "SetUpTest")
+	c.Check(helper.calls[2], Equals, "Test1")
+	c.Check(helper.calls[3], Equals, "TearDownTest")
+	c.Check(helper.calls[4], Equals, "SetUpTest")
+	c.Check(helper.calls[5], Equals, "Test2")
+	c.Check(helper.calls[6], Equals, "TearDownTest")
+	c.Check(helper.calls[7], Equals, "TearDownSuite")
+	c.Check(len(helper.calls), Equals, 8)
+}
+
+func (s *RunS) TestOldFilter(c *C) {
 	helper := FixtureHelper{}
 	output := String{}
 	runConf := RunConf{Output: &output, Filter: "Test[91]"}
@@ -209,74 +309,13 @@ func (s *RunS) TestFilterTestName(c *C) {
 	c.Check(len(helper.calls), Equals, 5)
 }
 
-func (s *RunS) TestFilterTestNameWithAll(c *C) {
+func (s *RunS) TestOldFilterError(c *C) {
 	helper := FixtureHelper{}
 	output := String{}
-	runConf := RunConf{Output: &output, Filter: ".*"}
-	Run(&helper, &runConf)
-	c.Check(helper.calls[0], Equals, "SetUpSuite")
-	c.Check(helper.calls[1], Equals, "SetUpTest")
-	c.Check(helper.calls[2], Equals, "Test1")
-	c.Check(helper.calls[3], Equals, "TearDownTest")
-	c.Check(helper.calls[4], Equals, "SetUpTest")
-	c.Check(helper.calls[5], Equals, "Test2")
-	c.Check(helper.calls[6], Equals, "TearDownTest")
-	c.Check(helper.calls[7], Equals, "TearDownSuite")
-	c.Check(len(helper.calls), Equals, 8)
-}
-
-func (s *RunS) TestFilterSuiteName(c *C) {
-	helper := FixtureHelper{}
-	output := String{}
-	runConf := RunConf{Output: &output, Filter: "FixtureHelper"}
-	Run(&helper, &runConf)
-	c.Check(helper.calls[0], Equals, "SetUpSuite")
-	c.Check(helper.calls[1], Equals, "SetUpTest")
-	c.Check(helper.calls[2], Equals, "Test1")
-	c.Check(helper.calls[3], Equals, "TearDownTest")
-	c.Check(helper.calls[4], Equals, "SetUpTest")
-	c.Check(helper.calls[5], Equals, "Test2")
-	c.Check(helper.calls[6], Equals, "TearDownTest")
-	c.Check(helper.calls[7], Equals, "TearDownSuite")
-	c.Check(len(helper.calls), Equals, 8)
-}
-
-func (s *RunS) TestFilterSuiteNameAndTestName(c *C) {
-	helper := FixtureHelper{}
-	output := String{}
-	runConf := RunConf{Output: &output, Filter: "FixtureHelper\\.Test2"}
-	Run(&helper, &runConf)
-	c.Check(helper.calls[0], Equals, "SetUpSuite")
-	c.Check(helper.calls[1], Equals, "SetUpTest")
-	c.Check(helper.calls[2], Equals, "Test2")
-	c.Check(helper.calls[3], Equals, "TearDownTest")
-	c.Check(helper.calls[4], Equals, "TearDownSuite")
-	c.Check(len(helper.calls), Equals, 5)
-}
-
-func (s *RunS) TestFilterAllOut(c *C) {
-	helper := FixtureHelper{}
-	output := String{}
-	runConf := RunConf{Output: &output, Filter: "NotFound"}
-	Run(&helper, &runConf)
-	c.Check(len(helper.calls), Equals, 0)
-}
-
-func (s *RunS) TestRequirePartialMatch(c *C) {
-	helper := FixtureHelper{}
-	output := String{}
-	runConf := RunConf{Output: &output, Filter: "est"}
-	Run(&helper, &runConf)
-	c.Check(len(helper.calls), Equals, 8)
-}
-
-func (s *RunS) TestFilterError(c *C) {
-	helper := FixtureHelper{}
-	output := String{}
-	runConf := RunConf{Output: &output, Filter: "]["}
+	runConf := RunConf{Output: &output, Filters: []string{"a"}, Filter: "b"}
 	result := Run(&helper, &runConf)
 	c.Check(result.String(), Equals,
-		"ERROR: Bad filter expression: error parsing regexp: missing closing ]: `[`")
+		"ERROR: Filter and Filters cannot be both set")
 	c.Check(len(helper.calls), Equals, 0)
 }
 
@@ -284,7 +323,7 @@ func (s *RunS) TestFilterError(c *C) {
 // Verify that List works correctly.
 
 func (s *RunS) TestListFiltered(c *C) {
-	names := List(&FixtureHelper{}, &RunConf{Filter: "1"})
+	names := List(&FixtureHelper{}, &RunConf{Filters: []string{"1"}})
 	c.Assert(names, DeepEquals, []string{
 		"FixtureHelper.Test1",
 	})


### PR DESCRIPTION
This PR enables multiple `-check.f` so as to allow filter configuration that cannot be easily expressed in regexp.

e.g. Execute `TestFoo` and `TestBar`, but skip `TestBaz`

```console
$ go test -check.f TestFoo -check.f TestBar .
```

My PR for docker https://github.com/docker/docker/pull/29775 depends on this PR.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>